### PR TITLE
fix: stream local videos from encoded urls

### DIFF
--- a/packages/iframe-worker/src/parts/FileSystem/FileSystem.ts
+++ b/packages/iframe-worker/src/parts/FileSystem/FileSystem.ts
@@ -1,5 +1,9 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
+export const exists = (uri: string): Promise<boolean> => {
+  return RendererWorker.invoke('FileSystem.exists', uri)
+}
+
 export const readFile = (uri: string): Promise<string> => {
   return RendererWorker.invoke('FileSystem.readFile', uri)
 }

--- a/packages/iframe-worker/src/parts/GetRemoteUrl/GetRemoteUrl.ts
+++ b/packages/iframe-worker/src/parts/GetRemoteUrl/GetRemoteUrl.ts
@@ -1,8 +1,23 @@
 import type { GetRemoteUrlOptions } from '../GetRemoteUrlOptions/GetRemoteUrlOptions.ts'
+import * as FileSystem from '../FileSystem/FileSystem.ts'
 import * as GetProtocol from '../GetProtocol/GetProtocol.ts'
 import * as GetRemoteUrlForWebView from '../GetRemoteUrlForWebView/GetRemoteUrlForWebView.ts'
 import * as PlatformState from '../PlatformState/PlatformState.ts'
 import * as PlatformType from '../PlatformType/PlatformType.ts'
+
+const getFilePath = (uri: string): string => {
+  if (uri.startsWith('file:')) {
+    return new URL(uri).pathname
+  }
+  return uri.startsWith('/') ? uri : `/${uri}`
+}
+
+const getRemoteFileUrl = async (uri: string): Promise<string> => {
+  if (!(await FileSystem.exists(uri))) {
+    throw new Error(`File not found: ${decodeURIComponent(getFilePath(uri))}`)
+  }
+  return `/remote${encodeURI(decodeURI(getFilePath(uri)))}`
+}
 
 export const getRemoteUrl = async (options: GetRemoteUrlOptions): Promise<string> => {
   const { uri } = options
@@ -11,20 +26,13 @@ export const getRemoteUrl = async (options: GetRemoteUrlOptions): Promise<string
   // then ask file system provider for remote url, for example disk file system provider or html file system provider
   const protocol = GetProtocol.getProtocol(uri)
   if (platform === PlatformType.Remote && !protocol) {
-    if (uri.startsWith('/')) {
-      return `/remote${uri}`
-    }
-    return `/remote/${uri}`
+    return getRemoteFileUrl(uri)
   }
-  if ((platform === PlatformType.Remote || platform === PlatformType.Electron) && protocol === 'file') {
-    const rest = uri.slice(7)
-    return `/remote${rest}`
+  if (protocol === 'file') {
+    return getRemoteFileUrl(uri)
   }
   if (platform === PlatformType.Electron && !protocol) {
-    if (uri.startsWith('/')) {
-      return `/remote${uri}`
-    }
-    return `/remote/${uri}`
+    return getRemoteFileUrl(uri)
   }
   return GetRemoteUrlForWebView.getRemoteUrlForWebView(options)
 }

--- a/packages/iframe-worker/test/GetRemoteUrl.test.ts
+++ b/packages/iframe-worker/test/GetRemoteUrl.test.ts
@@ -1,7 +1,16 @@
-import { expect, test } from '@jest/globals'
+import { beforeEach, expect, test } from '@jest/globals'
+import { RendererWorker, RpcId } from '@lvce-editor/rpc-registry'
 import * as GetRemoteUrl from '../src/parts/GetRemoteUrl/GetRemoteUrl.ts'
 import * as PlatformState from '../src/parts/PlatformState/PlatformState.ts'
 import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
+import * as RpcRegistry from '../src/parts/RpcRegistry/RpcRegistry.ts'
+
+beforeEach(() => {
+  RpcRegistry.remove(RpcId.RendererWorker)
+  RendererWorker.registerMockRpc({
+    'FileSystem.exists': async () => true,
+  })
+})
 
 test('remote platform - absolute path', async () => {
   PlatformState.setPlatform(PlatformType.Remote)
@@ -43,22 +52,36 @@ test('electron platform - relative path', async () => {
   expect(result).toBe('/remote/test/path')
 })
 
-test.skip('web platform', async () => {
+test('web platform - file uri with spaces', async () => {
   PlatformState.setPlatform(PlatformType.Web)
   const options = {
     id: 1,
-    uri: 'test/path',
+    uri: 'file:///test/video preview.mp4',
   }
   const result = await GetRemoteUrl.getRemoteUrl(options)
-  expect(result).toBe('/remote/test/path')
+  expect(result).toBe('/remote/test/video%20preview.mp4')
 })
 
-test.skip('uri with protocol', async () => {
+test('already encoded file uri', async () => {
   PlatformState.setPlatform(PlatformType.Remote)
   const options = {
     id: 1,
-    uri: 'file:///test/path',
+    uri: 'file:///test/video%20preview.mp4',
   }
   const result = await GetRemoteUrl.getRemoteUrl(options)
-  expect(result).toBe('/remote/test/path')
+  expect(result).toBe('/remote/test/video%20preview.mp4')
+})
+
+test('missing file', async () => {
+  RpcRegistry.remove(RpcId.RendererWorker)
+  RendererWorker.registerMockRpc({
+    'FileSystem.exists': async () => false,
+  })
+  PlatformState.setPlatform(PlatformType.Web)
+  const options = {
+    id: 1,
+    uri: 'file:///test/missing video.mp4',
+  }
+
+  await expect(GetRemoteUrl.getRemoteUrl(options)).rejects.toThrow('File not found: /test/missing video.mp4')
 })


### PR DESCRIPTION
Summary:
- stream local file videos through an encoded remote URL instead of loading the whole file into a Blob
- report a direct file-not-found error before initializing the video preview